### PR TITLE
fixed typo in spark batch processing code example

### DIFF
--- a/docs/spark/tutorials/batch-processing.md
+++ b/docs/spark/tutorials/batch-processing.md
@@ -117,7 +117,7 @@ The goal of this app is to gain some insights about the GitHub projects data. Ad
    // Average number of times each language has been forked
    DataFrame groupedDF = cleanedProjects
        .GroupBy("language")
-       .Agg(Avg(cleanedProjects["forked_from"]);
+       .Agg(Avg(cleanedProjects["forked_from"]));
    ```
 
 1. Add the following block of code to order the average number of forks in descending order to see which languages are the most forked. That is, the largest number of forks will appear first.
@@ -133,7 +133,7 @@ The goal of this app is to gain some insights about the GitHub projects data. Ad
    spark.Udf().Register<string, bool>(
        "MyUDF",
        (date) => DateTime.TryParse(date, out DateTime convertedDate) &&
-           (convertedDate > s_referenceDate);
+           (convertedDate > s_referenceDate));
    cleanedProjects.CreateOrReplaceTempView("dateView");
 
    DataFrame dateDf = spark.Sql(


### PR DESCRIPTION
fixed a typo in spark batch processing code example

## Summary

fixed a typo in two of the code examples for the spark batch processing tutorial
